### PR TITLE
add SC23 hpctest workshop in README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This working group is a new effort started as a result of a Birds-of-a-Feather s
 
 ## Events
 
+- [First International Workshop on HPC Testing and Evaluation of Systems, Tools, and Software](https://olcf.github.io/hpc-system-test-wg/hpctests/hpctests2023) at SC23
+  
 - [HPC System Testing: Looking ahead to Post-Exascale Systems and HPC Ecosystems](https://olcf.github.io/hpc-system-test-wg/events/sc22bof) at SC22
 
 - [HPC System Test: Towards Improving Availability and Portability of HPC Test Suites](https://olcf.github.io/hpc-system-test-wg/events/sc21bof) at SC21

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This working group is a new effort started as a result of a Birds-of-a-Feather s
 
 There are several ways you can get involved:
 
- - Join our Slack community at https://hpc-system-test.slack.com and discuss your thoughts
+ - Join our Slack community at [https://hpc-system-test.slack.com](https://hpc-system-test.slack.com) and discuss your thoughts
  - Share your test scripts or benchmarks with rest of community (e.g., link to git repos)
  - Participate in future conferences and events organized by the working group
 


### PR DESCRIPTION
@verolero86 take a look at this i saw that the events page didnt have SC23 workshop. 